### PR TITLE
Update pid.md

### DIFF
--- a/pid.md
+++ b/pid.md
@@ -16,7 +16,10 @@ Don't forget to save_config afterwards. It's annoying when you forget.
 
 
 1. If you find that after a period of time your heaters set themselves to zero, you're probably reaching idle timeout in klipper. You can change this in printer.cfg (it's in seconds).
-
+   [idle_timeout]
+   # Timeout in seconds (Seconds to minutes example: 1200=20min / 3600=60min etc.)
+   timeout: 2400
+   
 [Back](README.md)
 
 Further reading: 


### PR DESCRIPTION
I think it would be worthwhile to see the command and section in printer.cfg that is used to set the timeout values rather than hunting further to find that setting .. especially for newcomers who may have that question, rather than the old hats. The risk I guess is it becomes too big and cumbersome if every other little command is added.. but, I think in this section it is warranted. (Especially when the link to further reading has no mention of 'timeout' on the page meaning a lot more digging to find it.)